### PR TITLE
Fix ESLint issues

### DIFF
--- a/src/app/(admin)/admin/as/page.tsx
+++ b/src/app/(admin)/admin/as/page.tsx
@@ -33,7 +33,14 @@ export default function AsListPage() {
           { withCredentials: true }
         );
 
-        const mappedData: ASItem[] = response.data.map((item: any) => ({
+        interface ServiceItem {
+          asId: number;
+          asDescription?: string;
+          asName: string;
+          asStartTime?: string;
+        }
+
+        const mappedData: ASItem[] = response.data.map((item: ServiceItem) => ({
           id: item.asId,
           title: item.asDescription || "AS 신청",
           applicant: item.asName,

--- a/src/app/(admin)/admin/estimate/page.tsx
+++ b/src/app/(admin)/admin/estimate/page.tsx
@@ -164,9 +164,7 @@ export default function AsListPage() {
                     {getInstallStatusText(item.installStatus)}
                   </td>
                   <td className="py-3 px-4">
-                    {item.registeredUserGrade === "NOUSER"
-                      ? "비회원"
-                      : "회원"}
+                    {getUserGradeText(item.registeredUserGrade)}
                   </td>
                 </tr>
               ))}

--- a/src/app/(domain)/used-ac/page.tsx
+++ b/src/app/(domain)/used-ac/page.tsx
@@ -23,7 +23,17 @@ export default function UsedAcListPage() {
     axios
       .get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/used`, { withCredentials: true })
       .then((response) => {
-        const list: UsedAcItem[] = response.data.map((item: any) => ({
+        interface UsedResponse {
+          usedId: number;
+          usedName: string;
+          usedCost: number;
+          usedTime: string;
+          usedYear: string;
+          usedImages: string[];
+          usedDescription: string;
+        }
+
+        const list: UsedAcItem[] = response.data.map((item: UsedResponse) => ({
           id: item.usedId,
           title: item.usedName,
           price: item.usedCost,

--- a/src/hoc/withAdminAuth.tsx
+++ b/src/hoc/withAdminAuth.tsx
@@ -24,7 +24,7 @@ function withAdminAuth<P extends object>(WrappedComponent: React.ComponentType<P
       } else {
         setIsChecking(false);
       }
-    }, [authStore.user, authStore.isAuthenticated, router]);
+    }, [router]);
 
     if (isChecking) {
       return (

--- a/src/hooks/usePurchaseRequest.ts
+++ b/src/hooks/usePurchaseRequest.ts
@@ -5,7 +5,18 @@ import authStore from "@/utils/authStore";
 export default function usePurchaseRequest() {
   const router = useRouter();
 
-  const sendPurchaseRequest = async (usedId: number, payload: any) => {
+  interface PurchasePayload {
+    usedName: string;
+    usedCost: string;
+    productType: string;
+    usedDescription: string;
+    usedYear: string;
+    usedTime: string;
+    usedNote: string;
+    usedState: string;
+  }
+
+  const sendPurchaseRequest = async (usedId: number, payload: PurchasePayload) => {
     if (!authStore.isAuthenticated || !authStore.user) {
       alert("로그인이 필요합니다.");
       router.push("/login");

--- a/src/utils/useAddressSearch.ts
+++ b/src/utils/useAddressSearch.ts
@@ -1,12 +1,25 @@
 import { useState } from "react";
 
+interface PostcodeData {
+  address: string;
+}
+
+interface DaumWindow extends Window {
+  daum?: {
+    Postcode: new (options: { oncomplete: (data: PostcodeData) => void }) => {
+      open: () => void;
+    };
+  };
+}
+
 export function useAddressSearch() {
   const [address, setAddress] = useState("");
 
   const searchAddress = () => {
-    if (typeof window !== "undefined" && (window as any).daum?.Postcode) {
-      new (window as any).daum.Postcode({
-        oncomplete: (data: any) => {
+    const w = window as unknown as DaumWindow;
+    if (typeof window !== "undefined" && w.daum?.Postcode) {
+      new w.daum.Postcode({
+        oncomplete: (data: PostcodeData) => {
           setAddress(data.address);
         },
       }).open();


### PR DESCRIPTION
## Summary
- refine API response typing for AS list
- show grade text with helper function
- type used AC API data
- type purchase payload
- refine Daum Postcode typing
- simplify admin auth effect deps

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a77ffca808320a5b16c74c3da75ff