### PR TITLE
Add dashboard charts with React Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "react": "19.0.0",
     "react-datepicker": "^8.2.0",
     "react-dom": "19.0.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "recharts": "^2.8.0",
+    "@tanstack/react-query": "^5.34.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,22 +1,24 @@
 "use client";
 import React from "react";
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, XAxis, YAxis, Tooltip } from "recharts";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import { useAdminDashboard } from "@/hooks/useAdminDashboard";
 
 export default function AdminPage() {
-  // 임시 데이터
-  const estimateData = [
-    { id: 1, date: "2024-02-20", title: "가정집 에어컨 이전 설치 문의", status: "대기" },
-    { id: 2, date: "2024-02-18", title: "사무실 에어컨 설치", status: "완료" },
-  ];
+  const { data, isLoading } = useAdminDashboard();
+  const estimateData = data?.estimates ?? [];
+  const memberData = data?.members ?? [];
+  const noticeData = data?.notices ?? [];
+  const memberStats = data?.memberStats ?? [];
+  const noticeStats = data?.noticeStats ?? [];
 
-  const memberData = [
-    { id: 1, userName: "홍길동", email: "hong@example.com", joined: "2024-01-15" },
-    { id: 2, userName: "김철수", email: "chul@example.com", joined: "2024-02-10" },
-  ];
-
-  const noticeData = [
-    { id: 1, title: "공지사항 테스트", date: "2024-02-10", views: 120 },
-    { id: 2, title: "새로운 이벤트 안내", date: "2024-02-09", views: 45 },
-  ];
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <LoadingSpinner />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen flex bg-gray-100">
@@ -41,17 +43,25 @@ export default function AdminPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {estimateData.map((item) => (
-                    <tr key={item.id} className="border-b hover:bg-gray-50">
-                      <td className="py-2 px-2 text-sm">{item.date}</td>
-                      <td className="py-2 px-2 text-sm">{item.title}</td>
-                      <td className="py-2 px-2 text-sm">{item.status}</td>
-                      <td className="py-2 px-2">
-                        <button className="text-blue-500 mr-2">수정</button>
-                        <button className="text-red-500">삭제</button>
+                  {estimateData.length > 0 ? (
+                    estimateData.map((item) => (
+                      <tr key={item.id} className="border-b hover:bg-gray-50">
+                        <td className="py-2 px-2 text-sm">{item.date}</td>
+                        <td className="py-2 px-2 text-sm">{item.title}</td>
+                        <td className="py-2 px-2 text-sm">{item.status}</td>
+                        <td className="py-2 px-2">
+                          <button className="text-blue-500 mr-2">수정</button>
+                          <button className="text-red-500">삭제</button>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={4} className="py-4 text-center text-gray-500">
+                        데이터가 없습니다.
                       </td>
                     </tr>
-                  ))}
+                  )}
                 </tbody>
               </table>
             </div>
@@ -71,17 +81,25 @@ export default function AdminPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {memberData.map((item) => (
-                    <tr key={item.id} className="border-b hover:bg-gray-50">
-                      <td className="py-2 px-2 text-sm">{item.userName}</td>
-                      <td className="py-2 px-2 text-sm">{item.email}</td>
-                      <td className="py-2 px-2 text-sm">{item.joined}</td>
-                      <td className="py-2 px-2">
-                        <button className="text-blue-500 mr-2">수정</button>
-                        <button className="text-red-500">삭제</button>
+                  {memberData.length > 0 ? (
+                    memberData.map((item) => (
+                      <tr key={item.id} className="border-b hover:bg-gray-50">
+                        <td className="py-2 px-2 text-sm">{item.userName}</td>
+                        <td className="py-2 px-2 text-sm">{item.email}</td>
+                        <td className="py-2 px-2 text-sm">{item.joined}</td>
+                        <td className="py-2 px-2">
+                          <button className="text-blue-500 mr-2">수정</button>
+                          <button className="text-red-500">삭제</button>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={4} className="py-4 text-center text-gray-500">
+                        데이터가 없습니다.
                       </td>
                     </tr>
-                  ))}
+                  )}
                 </tbody>
               </table>
             </div>
@@ -101,17 +119,25 @@ export default function AdminPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {noticeData.map((notice) => (
-                    <tr key={notice.id} className="border-b hover:bg-gray-50">
-                      <td className="py-2 px-2 text-sm">{notice.title}</td>
-                      <td className="py-2 px-2 text-sm">{notice.date}</td>
-                      <td className="py-2 px-2 text-sm">{notice.views}</td>
-                      <td className="py-2 px-2">
-                        <button className="text-blue-500 mr-2">수정</button>
-                        <button className="text-red-500">삭제</button>
+                  {noticeData.length > 0 ? (
+                    noticeData.map((notice) => (
+                      <tr key={notice.id} className="border-b hover:bg-gray-50">
+                        <td className="py-2 px-2 text-sm">{notice.title}</td>
+                        <td className="py-2 px-2 text-sm">{notice.date}</td>
+                        <td className="py-2 px-2 text-sm">{notice.views}</td>
+                        <td className="py-2 px-2">
+                          <button className="text-blue-500 mr-2">수정</button>
+                          <button className="text-red-500">삭제</button>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={4} className="py-4 text-center text-gray-500">
+                        데이터가 없습니다.
                       </td>
                     </tr>
-                  ))}
+                  )}
                 </tbody>
               </table>
             </div>
@@ -120,22 +146,30 @@ export default function AdminPage() {
           {/* 통계 카드 */}
           <div className="bg-white rounded shadow p-4">
             <h2 className="text-xl font-semibold mb-3">통계</h2>
-            <div className="grid grid-cols-2 gap-4 text-center">
-              <div className="border rounded p-2">
-                <p className="text-sm text-gray-500">견적신청 수</p>
-                <p className="text-xl font-bold">127명</p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="h-60">
+                <p className="text-center mb-2 font-semibold">회원 통계</p>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={memberStats}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="date" />
+                    <YAxis allowDecimals={false} />
+                    <Tooltip />
+                    <Bar dataKey="count" fill="#3182ce" />
+                  </BarChart>
+                </ResponsiveContainer>
               </div>
-              <div className="border rounded p-2">
-                <p className="text-sm text-gray-500">공지사항 수</p>
-                <p className="text-xl font-bold">45건</p>
-              </div>
-              <div className="border rounded p-2">
-                <p className="text-sm text-gray-500">회원 수</p>
-                <p className="text-xl font-bold">128명</p>
-              </div>
-              <div className="border rounded p-2">
-                <p className="text-sm text-gray-500">기타</p>
-                <p className="text-xl font-bold">12명</p>
+              <div className="h-60">
+                <p className="text-center mb-2 font-semibold">게시글 통계</p>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={noticeStats}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="date" />
+                    <YAxis allowDecimals={false} />
+                    <Tooltip />
+                    <Bar dataKey="count" fill="#38a169" />
+                  </BarChart>
+                </ResponsiveContainer>
               </div>
             </div>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./styles/globals.css";
 import AuthUpdater from "../components/AuthUpdater";
+import ReactQueryProvider from "../components/ReactQueryProvider";
 import Header from "./(common)/header";
 import Footer from "./(common)/footer";
 import Script from "next/script";
@@ -38,11 +39,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body className="flex flex-col min-h-screen">
-        <AuthUpdater />
-        <Header />
-        <main className="flex-1 w-full">{children}</main>
-        <Footer />
-        <Chatbot />
+        <ReactQueryProvider>
+          <AuthUpdater />
+          <Header />
+          <main className="flex-1 w-full">{children}</main>
+          <Footer />
+          <Chatbot />
+        </ReactQueryProvider>
       </body>
     </html>
   );

--- a/src/components/ReactQueryProvider.tsx
+++ b/src/components/ReactQueryProvider.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import queryClient from '@/utils/queryClient';
+
+export default function ReactQueryProvider({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/hooks/useAdminDashboard.ts
+++ b/src/hooks/useAdminDashboard.ts
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+export interface EstimateItem {
+  id: number;
+  date: string;
+  title: string;
+  status: string;
+}
+
+export interface MemberItem {
+  id: number;
+  userName: string;
+  email: string;
+  joined: string;
+}
+
+export interface NoticeItem {
+  id: number;
+  title: string;
+  date: string;
+  views: number;
+}
+
+export interface StatItem {
+  date: string;
+  count: number;
+}
+
+export interface DashboardData {
+  estimates: EstimateItem[];
+  members: MemberItem[];
+  notices: NoticeItem[];
+  memberStats: StatItem[];
+  noticeStats: StatItem[];
+}
+
+const fetchDashboard = async (): Promise<DashboardData> => {
+  const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/dashboard`, {
+    withCredentials: true,
+  });
+  return res.data;
+};
+
+export const useAdminDashboard = () =>
+  useQuery({
+    queryKey: ['adminDashboard'],
+    queryFn: fetchDashboard,
+    refetchInterval: 5 * 60 * 1000,
+  });

--- a/src/utils/queryClient.ts
+++ b/src/utils/queryClient.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+    },
+  },
+});
+
+export default queryClient;


### PR DESCRIPTION
## Summary
- add Recharts and React Query libs
- setup QueryClient and provider
- fetch admin dashboard stats via React Query
- show loading spinner while fetching
- display members/posts charts

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbbe830b48320a7909573337c59a2