### PR TITLE
Use callback hooks for fetch functions

### DIFF
--- a/src/app/(user)/mypage/engineer/page.tsx
+++ b/src/app/(user)/mypage/engineer/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import axios from "axios";
 import authStore from "@/utils/authStore";
 import { EngineerStatus } from "@/types/mypage";
@@ -10,7 +10,7 @@ export default function MyPageEngineerApply() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  const fetchStatus = async () => {
+  const fetchStatus = useCallback(async () => {
     if (!authStore.isAuthenticated) return;
     try {
       const res = await axios.get(
@@ -23,7 +23,7 @@ export default function MyPageEngineerApply() {
       setError("상태를 불러오지 못했습니다.");
       console.error(error);
     }
-  };
+  }, []);
 
   const handleApply = async () => {
     if (!authStore.isAuthenticated) {
@@ -49,7 +49,7 @@ export default function MyPageEngineerApply() {
 
   useEffect(() => {
     fetchStatus();
-  }, []);
+  }, [fetchStatus]);
 
   const formattedDate = info?.appliedAt
     ? new Date(info.appliedAt).toLocaleDateString("ko-KR")

--- a/src/app/(user)/mypage/requests/page.tsx
+++ b/src/app/(user)/mypage/requests/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import axios from "axios";
 import authStore from "@/utils/authStore";
 import { getInstallStatusText } from "@/utils/transform";
@@ -11,7 +11,7 @@ export default function MyPageRequests() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     if (!authStore.isAuthenticated) return;
     setLoading(true);
     setError("");
@@ -49,11 +49,11 @@ export default function MyPageRequests() {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchData();
-  }, []);
+  }, [fetchData]);
 
   return (
     <div className="p-6 space-y-4">


### PR DESCRIPTION
## Summary
- stabilize `fetchStatus` and `fetchData` with `useCallback`
- include these callbacks in `useEffect` deps to silence lint warnings

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbeb727f8832091820cdfc3df09e8