### PR TITLE
Fix Admin Dashboard types

### DIFF
--- a/src/hooks/useAdminDashboard.ts
+++ b/src/hooks/useAdminDashboard.ts
@@ -5,6 +5,7 @@ import {
   ServiceResponse,
   CleanResponse,
 } from '@/types/response';
+import { MemberResponse, NoticeResponse } from '@/types/admin';
 
 export interface EstimateItem {
   id: number;
@@ -86,7 +87,7 @@ const fetchMembers = async (): Promise<MemberItem[]> => {
     `${process.env.NEXT_PUBLIC_API_URL}/api/v1/user/all`,
     { withCredentials: true }
   );
-  return res.data.map((it: any) => ({
+  return res.data.map((it: MemberResponse) => ({
     id: it.userLogin,
     userName: it.userName,
     email: it.email,
@@ -99,7 +100,7 @@ const fetchNotices = async (): Promise<NoticeItem[]> => {
     `${process.env.NEXT_PUBLIC_API_URL}/api/v1/notices`,
     { withCredentials: true }
   );
-  return res.data.map((it: any) => ({
+  return res.data.map((it: NoticeResponse) => ({
     id: it.id,
     title: it.title,
     date: it.postTime,

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,0 +1,19 @@
+export interface MemberResponse {
+  userLogin: string;
+  userName: string;
+  email: string;
+  phoneNumber: string;
+  joinDate: string;
+  userGrade: string;
+  status: boolean;
+}
+
+export interface NoticeResponse {
+  id: number;
+  title: string;
+  writer: string;
+  postTime: string;
+  editTime?: string;
+  deleteTime?: string;
+  viewCount?: number;
+}


### PR DESCRIPTION
## Summary
- add admin API response types
- use these types in `useAdminDashboard` instead of `any`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd4411f2483209b14757b613a9408